### PR TITLE
Create a readonly activity feed of organizer channels in civictechto slack

### DIFF
--- a/config/config-heroku-template.toml
+++ b/config/config-heroku-template.toml
@@ -298,3 +298,23 @@ enable=true
   [[gateway.inout]]
   account="slack.yowcivictech"
   channel="organizing-canada"
+
+[[gateway]]
+name="organizing-feed"
+enable=true
+  [[gateway.out]]
+  account="slack.civictechto"
+  channel="organizing-feed"
+
+  [[gateway.in]]
+  account="slack.civictechto"
+  channel="operations"
+  [[gateway.in]]
+  account="slack.civictechlondon"
+  channel="organizing"
+  [[gateway.in]]
+  account="slack.civictechwr"
+  channel="organizing"
+  [[gateway.in]]
+  account="slack.yowcivictech"
+  channel="organizers"


### PR DESCRIPTION
This will allow people to easily skim other organizer convos without inviting noisy convo, and without requiring organizers to visit other slack teams.