### PR TITLE
Remove bridge for EDGI lobby

### DIFF
--- a/config/config-heroku-template.toml
+++ b/config/config-heroku-template.toml
@@ -158,19 +158,6 @@ enable=true
   channel="webmonitoring"
 
 [[gateway]]
-name="edgi-public-lobby"
-enable=true
-  [[gateway.inout]]
-  account="slack.edgi"
-  channel="public-lobby"
-  [[gateway.inout]]
-  account="slack.archivers"
-  channel="public-lobby"
-  [[gateway.inout]]
-  account="gitter.gitter"
-  channel="edgi-govdata-archiving/Lobby"
-
-[[gateway]]
 name="oc-edgi"
 enable=false # archived on EDGI side
   [[gateway.inout]]


### PR DESCRIPTION
`edgi-public-lobby` channel is not used and has been archived. I'm also testing making changes to config